### PR TITLE
Bug fix for JSON file loading

### DIFF
--- a/src/client/ai/DeepAI.cpp
+++ b/src/client/ai/DeepAI.cpp
@@ -5,8 +5,6 @@
 #include <iterator>
 #include <algorithm>
 #include <vector>
-//#include<bits/stdc++.h> // min max function
-#include </usr/local/include/bits/stdc++.h> // Pour MACOS
 
 //using namespace client;
 using namespace state;

--- a/src/client/render/Surface.cpp
+++ b/src/client/render/Surface.cpp
@@ -18,8 +18,8 @@ namespace render {
 
         if (!mTexture.loadFromFile(lResPath))
         {
-            cout << "ERROR : Failed to load texture " << rTextureName <<endl;
-            return -1;
+            cout << "ERROR : Failed to load texture " << lResPath <<endl;
+            throw new std::runtime_error("File not found! (" + lResPath + ")");
         }
 
         else{
@@ -65,8 +65,8 @@ namespace render {
         
         if (!mTexture.loadFromFile(lResPath))
         {
-            cout << "ERROR : Failed to load texture " << rTextureName <<endl;
-            return -1;
+            cout << "ERROR : Failed to load texture " << lResPath <<endl;
+            throw new std::runtime_error("File not found! (" + lResPath + ")");
         }
 
         else{
@@ -87,8 +87,8 @@ namespace render {
 
         if (!mTexture.loadFromFile(lResPath))
         {
-            cout << "ERROR : Failed to load texture " << rTextureName <<endl;
-            return -1;
+            cout << "ERROR : Failed to load texture " << lResPath <<endl;
+            throw new std::runtime_error("File not found! (" + lResPath + ")");
         }
 
         else{

--- a/src/shared/state/JSON_Tools.cpp
+++ b/src/shared/state/JSON_Tools.cpp
@@ -2,11 +2,7 @@
 #include "Character.h"
 #include <iostream>
 #include <fstream>
-//#include <jsoncpp/json/json.h>
-//#include <jsoncpp/json/value.h>
-
-#include </usr/local/include/json/json.h> //MacOS
-#include </usr/local/include/json/json.h> //MacOS
+#include <json/json.h>
 #include <string>
 
 using namespace std;
@@ -21,7 +17,12 @@ namespace state {
 
     }ActionContainer;
     void JSON_tools::JSON_Configure_Character (Character& rCharacter) {
-        std::ifstream ifs("res/JSON_files/statistics.json");
+        std::string filename = "res/JSON_files/statistics.json";
+        std::ifstream ifs(filename);
+        if (!ifs.is_open()) {
+            std::cout << "failed to open " << filename << '\n';
+            throw std::runtime_error("File not found! (" + filename + ")");
+        }
         string lAction_Name[] = {"ACTION_1", "ACTION_2", "ACTION_3", "ACTION_4"};
         string lAction_Type[] = {"ATTACK_1", "ATTACK_2", "SPELL_1", "SPELL_2"};
         Json::Reader reader;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,6 +76,7 @@ function(add_custom_test name)
   # Add test to CTest
   add_test(NAME ${target_name}
     COMMAND $<TARGET_FILE:${target_name}>
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
 
   # Add dependency to build test target before code coverage

--- a/test/client/test_client_dummy.cpp
+++ b/test/client/test_client_dummy.cpp
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(TestRenderLayer){
   {
     RenderLayer lRender;
     sf::RenderWindow window(sf::VideoMode(800, 600, 32), "ENSEAi");
-    static int lArena_Number;
+    int lArena_Number = 1;
     lRender.LoadBackground(lArena_Number);
 
     lRender.LoadCharacter(1,250,250,1);
@@ -141,9 +141,9 @@ BOOST_AUTO_TEST_CASE(NewTestSurface){
     sf::RenderWindow window;
 
 
-    lSurface.LoadShape("Arena1.png",0,0);
-    lSurface.LoadCharacterSprite("Character1.png",0,0,0);
-    lSurface.LoadBackgroundSprite("Arena2.png");
+    lSurface.LoadShape("backgrounds/Arena1.png",0,0);
+    lSurface.LoadCharacterSprite("sprites/Character1.png",0,0,0);
+    lSurface.LoadBackgroundSprite("backgrounds/Arena2.png");
     lSurface.SetCharacterAnimation(0);
     lSurface.UpdateCharacterAnimation(1);
 


### PR DESCRIPTION
The problem come from a bad path to retrieve resources (res/).
I fix it by running test from the project root folder.

I also fix several problems:
- adding jsoncpp lib to cmake file
- wrong files loaded in tests
- raise Runtime exception when a file is not found (so it cannot failed silently anymore). It's a better way to manage errors than return value (in object language).
- remove <bits/stdc++.h> import (in general, not a good idea). min & max functions lie in <algorithm>)